### PR TITLE
Diagnose generic methods cleanly

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,7 @@ roadmap:
 - `static` requirements, initializers, subscripts, and associated types
 - throwing / async property accessors
 - `inout` and variadic parameters
+- generic methods (a method-scoped generic can't be tracked at type scope)
 
 ## Failure reporting
 

--- a/Sources/SwiftMocksMacros/SwiftMocksMacro.swift
+++ b/Sources/SwiftMocksMacros/SwiftMocksMacro.swift
@@ -112,6 +112,8 @@ private func unsupportedFeature(in proto: ProtocolDeclSyntax) -> MockDiagnostic?
 
         if let function = decl.as(FunctionDeclSyntax.self) {
             if isStatic(function.modifiers) { return .staticUnsupported }
+            // A method-scoped generic parameter can't appear in a type-scoped tracker.
+            if function.genericParameterClause != nil { return .genericUnsupported }
             for param in function.signature.parameterClause.parameters {
                 // These can't live in the tracker's argument tuple / stub closure.
                 if param.ellipsis != nil { return .variadicUnsupported }
@@ -149,6 +151,7 @@ private func unsupportedClassMember(in classDecl: ClassDeclSyntax) -> MockDiagno
             if has(f.modifiers, .final) { return .finalUnsupported }
             if has(f.modifiers, .static, .class) { return .staticUnsupported }
             if has(f.modifiers, .private, .fileprivate) { return .privateUnsupported }
+            if f.genericParameterClause != nil { return .genericUnsupported }
             for param in f.signature.parameterClause.parameters {
                 if param.ellipsis != nil { return .variadicUnsupported }
                 if param.type.trimmedDescription.hasPrefix("inout ") { return .inoutUnsupported }
@@ -450,4 +453,5 @@ private struct MockDiagnostic: DiagnosticMessage {
     static let effectfulAccessorUnsupported = MockDiagnostic("'@Mock' does not yet support throwing or async property accessors", "effectfulAccessorUnsupported")
     static let variadicUnsupported = MockDiagnostic("'@Mock' does not yet support variadic parameters", "variadicUnsupported")
     static let inoutUnsupported = MockDiagnostic("'@Mock' does not yet support 'inout' parameters", "inoutUnsupported")
+    static let genericUnsupported = MockDiagnostic("'@Mock' does not yet support generic methods (a method-scoped generic parameter can't be tracked); use a concrete or existential type", "genericUnsupported")
 }

--- a/Tests/SwiftMocksTests/SwiftMocksTests.swift
+++ b/Tests/SwiftMocksTests/SwiftMocksTests.swift
@@ -368,6 +368,26 @@ final class MockDiagnosticsTests: XCTestCase {
         )
     }
 
+    func testGenericMethodIsDiagnosed() {
+        assertMacroExpansion(
+            """
+            @Mock
+            protocol Transformer {
+                func transform<T>(_ value: T) -> T
+            }
+            """,
+            expandedSource: """
+            protocol Transformer {
+                func transform<T>(_ value: T) -> T
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(message: "'@Mock' does not yet support generic methods (a method-scoped generic parameter can't be tracked); use a concrete or existential type", line: 1, column: 1)
+            ],
+            macros: testMacros
+        )
+    }
+
     func testSubscriptRequirementIsDiagnosed() {
         assertMacroExpansion(
             """


### PR DESCRIPTION
## Summary

Generic methods (e.g. `func transform<T>(_ value: T) -> T`) previously **mis-generated** — the macro emitted a tracker referencing a method-scoped generic at type scope, producing a cryptic `cannot find type 'T' in scope`. This adds a clear compile-time diagnostic in both the protocol and class validation passes, consistent with how the library handles every other unsupported feature.

Full generic-method *support* would require type-erasing the tracker (`Any` storage + force casts), which breaks the type-safe `.stub`/`.verify` API — so it's intentionally deferred rather than bolted on unsafely.

Addresses the generic-method portion of #3 (async/throws shipped in #8).

## Changes
- Detect `genericParameterClause` on methods → `genericUnsupported` diagnostic.
- Test asserting the diagnostic.
- README limitations updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)